### PR TITLE
Add extra fields for metric values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Random
+.DS_Store
 
 # Bundler config
 Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.8 (XXXX, 2017) ##
+
+* Add metric-specific fields to calculator output
+
 ## Dradis Framework 3.7 (July, 2017) ##
 
 * Add mouseover details to each button

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/calculator.js.coffee
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/calculator.js.coffee
@@ -56,6 +56,27 @@
       issue_cvss += "#{output.environmentalMetricScore}\n\n"
       issue_cvss += "#[CVSSv3.EnvironmentalSeverity]#\n"
       issue_cvss += "#{output.environmentalSeverity}\n\n"
+      
+      issue_cvss += "#[CVSSv3.BaseAttackVector]#\n"
+      issue_cvss += "#{output.baseAttackVector}\n\n"
+      issue_cvss += "#[CVSSv3.BaseAttackComplexity]#\n"
+      issue_cvss += "#{output.baseAttackComplexity}\n\n"
+      issue_cvss += "#[CVSSv3.BasePrivilegesRequired]#\n"
+      issue_cvss += "#{output.basePrivilegesRequired}\n\n"
+      issue_cvss += "#[CVSSv3.BaseUserInteraction]#\n"
+      issue_cvss += "#{output.baseUserInteraction}\n\n"
+      issue_cvss += "#[CVSSv3.BaseScope]#\n"
+      issue_cvss += "#{output.baseScope}\n\n"
+      issue_cvss += "#[CVSSv3.BaseConfidentiality]#\n"
+      issue_cvss += "#{output.baseConfidentiality}\n\n"
+      issue_cvss += "#[CVSSv3.BaseIntegrity]#\n"
+      issue_cvss += "#{output.baseIntegrity}\n\n"
+      issue_cvss += "#[CVSSv3.BaseAvailability]#\n"
+      issue_cvss += "#{output.baseAvailability}\n\n"
+      issue_cvss += "#[CVSSv3.EnvironmentalConfidentialityRequirement]#\n"
+      issue_cvss += "#{output.environmentalConfidentialityRequirement}\n\n"
+      issue_cvss += "#[CVSSv3.EnvironmentalIntegrityRequirement]#\n"
+      issue_cvss += "#{output.environmentalIntegrityRequirement}\n\n"
       $('#blob').text(issue_cvss)
     else
       if output.errorType == 'MissingBaseMetric'

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/vendor/cvsscalc30.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/vendor/cvsscalc30.js
@@ -352,12 +352,21 @@ CVSS.calculateCVSSFromMetrics = function (
     success: true,
     baseMetricScore: baseScore.toFixed(1),
     baseSeverity: CVSS.severityRating( baseScore.toFixed(1) ),
-
     temporalMetricScore: temporalScore.toFixed(1),
     temporalSeverity: CVSS.severityRating( temporalScore.toFixed(1) ),
-
     environmentalMetricScore: envScore.toFixed(1),
     environmentalSeverity: CVSS.severityRating( envScore.toFixed(1) ),
+
+    baseAttackVector: CVSS.XML_MetricNames["MAV"][AttackVector],
+    baseAttackComplexity: CVSS.XML_MetricNames["MAC"][AttackComplexity],
+    basePrivilegesRequired: CVSS.XML_MetricNames["MPR"][PrivilegesRequired],
+    baseUserInteraction: CVSS.XML_MetricNames["MUI"][UserInteraction],
+    baseScope: CVSS.XML_MetricNames["MS"][Scope],
+    baseConfidentiality: CVSS.XML_MetricNames["MCIA"][Confidentiality],
+    baseIntegrity: CVSS.XML_MetricNames["MCIA"][Integrity],
+    baseAvailability: CVSS.XML_MetricNames["MCIA"][Availability],
+    environmentalConfidentialityRequirement: CVSS.XML_MetricNames["CIAR"][ConfidentialityRequirement || "X"],
+    environmentalIntegrityRequirement: CVSS.XML_MetricNames["CIAR"][IntegrityRequirement || "X"],
 
     vectorString: vectorString
   };
@@ -483,17 +492,17 @@ CVSS.severityRating = function (score) {
 // because the latter is the same as the former, except it also includes a "NOT_DEFINED" value.
 
 CVSS.XML_MetricNames = {
-  E:    { X: "NOT_DEFINED", U: "UNPROVEN",     P: "PROOF_OF_CONCEPT",  F: "FUNCTIONAL",  H: "HIGH"},
-  RL:   { X: "NOT_DEFINED", O: "OFFICIAL_FIX", T: "TEMPORARY_FIX",     W: "WORKAROUND",  U: "UNAVAILABLE"},
-  RC:   { X: "NOT_DEFINED", U: "UNKNOWN",      R: "REASONABLE",        C: "CONFIRMED"},
+  E:    { X: "Not Defined", U: "Unproven",     P: "Proof of Concept",  F: "Functional",  H: "High"},
+  RL:   { X: "Not Defined", O: "Official Fix", T: "Temporary Fix",     W: "Workaround",  U: "Unavailable"},
+  RC:   { X: "Not Defined", U: "Unknown",      R: "Reasonable",        C: "Confirmed"},
 
-  CIAR: { X: "NOT_DEFINED", L: "LOW",              M: "MEDIUM", H: "HIGH"},         // CR, IR and AR use the same metric names
-  MAV:  { N: "NETWORK",     A: "ADJACENT_NETWORK", L: "LOCAL",  P: "PHYSICAL", X: "NOT_DEFINED" },
-  MAC:  { H: "HIGH",        L: "LOW",              X: "NOT_DEFINED" },
-  MPR:  { N: "NONE",        L: "LOW",              H: "HIGH",   X: "NOT_DEFINED" },
-  MUI:  { N: "NONE",        R: "REQUIRED",         X: "NOT_DEFINED" },
-  MS:   { U: "UNCHANGED",   C: "CHANGED",          X: "NOT_DEFINED" },
-  MCIA: { N: "NONE",        L: "LOW",              H: "HIGH",   X: "NOT_DEFINED" }  // C, I and A use the same metric names
+  CIAR: { X: "Not Defined", L: "Low",              M: "Medium", H: "High"},         // CR, IR and AR use the same metric names
+  MAV:  { N: "Network",     A: "Adjacent Network", L: "Local",  P: "Physical", X: "Not Defined" },
+  MAC:  { H: "High",        L: "Low",              X: "Not Defined" },
+  MPR:  { N: "None",        L: "Low",              H: "High",   X: "Not Defined" },
+  MUI:  { N: "None",        R: "Required",         X: "Not Defined" },
+  MS:   { U: "Unchanged",   C: "Changed",          X: "Not Defined" },
+  MCIA: { N: "None",        L: "Low",              H: "High",   X: "Not Defined" }  // C, I and A use the same metric names
 };
 
 
@@ -589,7 +598,7 @@ CVSS.generateXMLFromMetrics = function (
   }
 
   var xmlOutput = xmlTemplate;
-  xmlOutput = xmlOutput.replace ("__AttackVector__",        CVSS.XML_MetricNames["MAV"][AttackVector]);
+  xmlOutput = xmlOutput.replace ("__AttackVector__",        CVSS.XML_MetricNames["MAC"][AttackVector]);
   xmlOutput = xmlOutput.replace ("__AttackComplexity__",    CVSS.XML_MetricNames["MAC"][AttackComplexity]);
   xmlOutput = xmlOutput.replace ("__PrivilegesRequired__",  CVSS.XML_MetricNames["MPR"][PrivilegesRequired]);
   xmlOutput = xmlOutput.replace ("__UserInteraction__",     CVSS.XML_MetricNames["MUI"][UserInteraction]);

--- a/app/views/dradis/plugins/calculators/cvss/base/index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/index.html.erb
@@ -152,10 +152,12 @@
         <div class="span6">
           <h3 title="This metric reflects the context by which vulnerability exploitation is possible. The Base Score increases the more remote (logically, and physically) an attacker can be in order to exploit the vulnerable component.">Mod. Attack Vector (MAV)</h3>
           <input type="hidden" id="mav" />
-          <div class="btn-group" data-toggle="buttons-radio">
+          <div class="btn-group-vertical" data-toggle="buttons-radio">
             <button type="button" class="btn btn-med active" name="mav" value="X" title="Use the value assigned to the corresponding Base Score metric.">Not Defined (X) <i class="fa fa-question-circle-o" aria-hidden="true"></i></button>
             <button type="button" class="btn btn-med" name="mav" value="N" title="A vulnerability exploitable with network access means the vulnerable component is bound to the network stack and the attacker's path is through OSI layer 3 (the network layer). Such a vulnerability is often termed 'remotely exploitable' and can be thought of as an attack being exploitable one or more network hops away.">Network (N) <i class="fa fa-question-circle-o" aria-hidden="true"></i></button>
             <button type="button" class="btn btn-med" name="mav" value="A" title="A vulnerability exploitable with adjacent network access means the vulnerable component is bound to the network stack, however the attack is limited to the same shared physical (e.g. Bluetooth, IEEE 802.11), or logical (e.g. local IP subnet) network, and cannot be performed across an OSI layer 3 boundary (e.g. a router).">Adjacent (A) <i class="fa fa-question-circle-o" aria-hidden="true"></i></button>
+          </div>
+          <div class="btn-group-vertical" data-toggle="buttons-radio">  
             <button type="button" class="btn btn-med" name="mav" value="L" title="A vulnerability exploitable with local access means that the vulnerable component is not bound to the network stack, and the attacker’s path is via read/write/execute capabilities. In some cases, the attacker may be logged in locally in order to exploit the vulnerability, otherwise, she may rely on User Interaction to execute a malicious file.">Local (L) <i class="fa fa-question-circle-o" aria-hidden="true"></i></button>
             <button type="button" class="btn btn-med" name="mav" value="P" title="A vulnerability exploitable with physical access requires the attacker to physically touch or manipulate the vulnerable component. Physical interaction may be brief or persistent.">Physical (P) <i class="fa fa-question-circle-o" aria-hidden="true"></i></button>
           </div>
@@ -247,6 +249,18 @@ N/A
 
 #[CVSSv3.EnvironmentalSeverity]#
 N/A
+
+#[CVSSv3.BaseAttackVector]#
+#[CVSSv3.BaseAttackComplexity]#
+#[CVSSv3.BasePrivilegesRequired]#
+#[CVSSv3.BaseUserInteraction]#
+#[CVSSv3.BaseScope]#
+#[CVSSv3.BaseConfidentiality]#
+#[CVSSv3.BaseIntegrity]#
+#[CVSSv3.BaseAvailability]#
+#[CVSSv3.EnvironmentalConfidentialityRequirement]#
+#[CVSSv3.EnvironmentalIntegrityRequirement]#
+
 </pre>
   </div>
 </div>

--- a/lib/dradis/plugins/calculators/cvss/gem_version.rb
+++ b/lib/dradis/plugins/calculators/cvss/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
 
         module VERSION
           MAJOR = 3
-          MINOR = 7
+          MINOR = 8
           TINY = 0
           PRE = nil
 

--- a/lib/dradis/plugins/calculators/cvss/gem_version.rb
+++ b/lib/dradis/plugins/calculators/cvss/gem_version.rb
@@ -10,7 +10,7 @@ module Dradis
         module VERSION
           MAJOR = 3
           MINOR = 8
-          TINY = 0
+          TINY = 1
           PRE = nil
 
           STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
This PR adds extra fields so that the metric-specific values (e.g. `CVSSv3.BaseAttackVector`) can be exported into reports. 