### PR TITLE
Relax vector condition and allow empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,37 @@
-## Dradis Framework 3.12 (March, 2019) ##
+# Dradis Framework 3.12 (Xxx, YYY) ##
+*  Allow empty 'CVSSv3.Vector' field to trigger the per-issue calculator.
+
+
+# Dradis Framework 3.12 (March, 2019) ##
 
 *  Present a per-issue CVSSv3 calculator.
+
 
 ## Dradis Framework 3.11 (November, 2018) ##
 
 * No changes
 
+
 ## Dradis Framework 3.10 (August, 2018) ##
 
 * Fix vertical button selection behavior
+
 
 ## Dradis Framework 3.9 (January, 2018) ##
 
 * Add metric-specific fields to calculator output (v3.8.1)
 
+
 ## Dradis Framework 3.8 (September, 2017) ##
 
 * No changes.
+
 
 ## Dradis Framework 3.7 (July, 2017) ##
 
 * Add mouseover details to each button
 * Add "High" as an option for Exploit Code Maturity (E)
+
 
 ## Dradis Framework 3.6 (March XX, 2017) ##
 

--- a/app/controllers/dradis/plugins/calculators/cvss/issues_controller.rb
+++ b/app/controllers/dradis/plugins/calculators/cvss/issues_controller.rb
@@ -25,7 +25,7 @@ module Dradis::Plugins::Calculators::CVSS
       field_value  = @issue.fields['CVSSv3.Vector'] || @issue.fields['CVSSv3Vector']
 
       # If no vector is set yet, that's OK
-      return unless field_value
+      return if field_value.blank?
 
       if field_value =~ V3::VECTOR_REGEXP
         field_value.split('/').each { |pair| @cvss_vector.store *pair.split(':') }

--- a/lib/dradis/plugins/calculators/cvss/gem_version.rb
+++ b/lib/dradis/plugins/calculators/cvss/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
 
         module VERSION
           MAJOR = 3
-          MINOR = 12
+          MINOR = 13
           TINY = 0
           PRE = nil
 


### PR DESCRIPTION
Before this PR an Issue w/ `CVSSv3.Vector` field set to an empty value would prevent the calculator from loading.

After this PR, we consider the empty value the same as the no-field condition and allow the calculator to render with all values defaulting to `X`.