### PR TITLE
Update ActiveRecord::Base.connection to use with_connection for Rails 7.2 compatibility

### DIFF
--- a/lib/dradis/plugins/calculators/cvss/engine.rb
+++ b/lib/dradis/plugins/calculators/cvss/engine.rb
@@ -26,12 +26,14 @@ module Dradis::Plugins::Calculators::CVSS
       # initialization, we first check if the DB is loaded and the Configuration
       # table has been created, before checking if the engine is enabled
       Rails.application.reloader.to_prepare do
-        if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
-          Rails.application.routes.append do
-            # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
-            # check inside the block to ensure the routes can be re-enabled without a server restart
-            if Engine.enabled?
-              mount Engine => '/', as: :cvss_calculator
+        ActiveRecord::Base.lease_connection do
+          if ::Configuration.table_exists?
+            Rails.application.routes.append do
+              # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+              # check inside the block to ensure the routes can be re-enabled without a server restart
+              if Engine.enabled?
+                mount Engine => '/', as: :cvss_calculator
+              end
             end
           end
         end

--- a/lib/dradis/plugins/calculators/cvss/engine.rb
+++ b/lib/dradis/plugins/calculators/cvss/engine.rb
@@ -26,7 +26,7 @@ module Dradis::Plugins::Calculators::CVSS
       # initialization, we first check if the DB is loaded and the Configuration
       # table has been created, before checking if the engine is enabled
       Rails.application.reloader.to_prepare do
-        ActiveRecord::Base.lease_connection do
+        ActiveRecord::Base.with_connection do
           if ::Configuration.table_exists?
             Rails.application.routes.append do
               # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable


### PR DESCRIPTION
### Summary
In Rails 7.2, ActiveRecord::Base.connection behaviour has changed. It no longer raises an exception when there is no db, but it instantiates a connection instead. According to the Rails documentation, `with_connection` and `lease_connection` are the new alternatives

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
