### PR TITLE
Remove configuration table check as it is now done in dradis-plugins

### DIFF
--- a/lib/dradis/plugins/calculators/cvss/engine.rb
+++ b/lib/dradis/plugins/calculators/cvss/engine.rb
@@ -22,9 +22,6 @@ module Dradis::Plugins::Calculators::CVSS
     end
 
     initializer 'calculator_cvss.mount_engine' do
-      # By default, this engine is loaded into the main app. So, upon app
-      # initialization, we first check if the DB is loaded and the Configuration
-      # table has been created, before checking if the engine is enabled
       Rails.application.reloader.to_prepare do
         Rails.application.routes.append do
           # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable

--- a/lib/dradis/plugins/calculators/cvss/engine.rb
+++ b/lib/dradis/plugins/calculators/cvss/engine.rb
@@ -26,13 +26,11 @@ module Dradis::Plugins::Calculators::CVSS
       # initialization, we first check if the DB is loaded and the Configuration
       # table has been created, before checking if the engine is enabled
       Rails.application.reloader.to_prepare do
-        if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
-          Rails.application.routes.append do
-            # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
-            # check inside the block to ensure the routes can be re-enabled without a server restart
-            if Engine.enabled?
-              mount Engine => '/', as: :cvss_calculator
-            end
+        Rails.application.routes.append do
+          # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+          # check inside the block to ensure the routes can be re-enabled without a server restart
+          if Engine.enabled?
+            mount Engine => '/', as: :cvss_calculator
           end
         end
       end


### PR DESCRIPTION
### Summary
Previously, we needed to check `if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?` before checking `engine.enabled?`. We are now doing this check in [dradis-plugins](https://github.com/dradis/dradis-plugins/pull/101) so we can remove it here


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
