### PR TITLE
prevent unneeded combobox for version select

### DIFF
--- a/app/views/dradis/plugins/calculators/cvss/_version_menu.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/_version_menu.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex align-items-center justify-content-end gap-2 small">
   <label class="form-label m-0" for="cvss-version">Version:</label>
-  <select id="cvss-version" class="form-select" aria-label="cvss version select" data-behavior="cvss-version">
+  <select id="cvss-version" class="form-select" aria-label="cvss version select" data-behavior="cvss-version" data-combobox-config="no-combobox">
     <option value="40" <%= 'selected' if @cvss_version == '4.0' %>>v4.0</option>
     <option value="31" <%= 'selected' if @cvss_version == '3.1' %>>v3.1</option>
     <option value="30" <%= 'selected' if @cvss_version == '3.0' %>>v3.0</option>


### PR DESCRIPTION
## Summary

This change prevents unnecessary initialization of a combobox for the version select.

### Testing Steps

Provide steps to test functionality, described in detail for someone not familiar with this part of the application/code base

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
