### PR TITLE
redesign standalone CVSS v4.0 calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.#.0 (Month 2026)
+  - Standalone calculator: redesign with two-column layout, sticky results panel, severity badges, and vector string copy
+
 v5.1.0 (May 2026)
   - No changes
 

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/base.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/base.js
@@ -1,3 +1,7 @@
+//= require jquery3
+//= require popper
+//= require bootstrap
+
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc30
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc30_helptext
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc31

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/base.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/base.js
@@ -1,7 +1,3 @@
-//= require jquery3
-//= require popper
-//= require bootstrap
-
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc30
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc30_helptext
 //= require dradis/plugins/calculators/cvss/v3/vendor/cvsscalc31

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/cvss.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/cvss.js
@@ -1,55 +1,57 @@
-$(document).on('turbo:load', function () {
-  if ($('[data-behavior~=cvss-version]').length) {
-    function handleVersionSelection() {
-      var selectedValue = $('[data-behavior~=cvss-version]').val();
-      $('[data-cvss-version]').addClass('d-none');
-      switch (selectedValue) {
-        case '40':
-          $('[data-cvss-version=4]').removeClass('d-none');
-          window.calculator = new CVSS40Calculator();
-          break;
-        case '31':
-          $('[data-cvss-version=3]').removeClass('d-none');
-          window.calculator = new CVSS31Calculator();
-          break;
-        case '30':
-          $('[data-cvss-version=3]').removeClass('d-none');
-          window.calculator = new CVSS30Calculator();
-          break;
-      }
+$(document).on('turbo:load', () => {
+  if (!$('[data-behavior~=cvss-version]').length) return;
+
+  const isStandalone = $('[data-behavior~=cvss-calculator]').length > 0;
+
+  const handleVersionSelection = () => {
+    const selectedValue = $('[data-behavior~=cvss-version]').val();
+    $('[data-cvss-version]').addClass('d-none');
+
+    switch (selectedValue) {
+      case '40':
+        $('[data-cvss-version=4]').removeClass('d-none');
+        window.calculator = new CVSS40Calculator();
+        break;
+      case '31':
+        $('[data-cvss-version=3]').removeClass('d-none');
+        window.calculator = new CVSS31Calculator();
+        break;
+      case '30':
+        $('[data-cvss-version=3]').removeClass('d-none');
+        window.calculator = new CVSS30Calculator();
+        break;
     }
-    handleVersionSelection();
-    $('[data-behavior~=cvss-error]').addClass('d-none');
+  };
 
-    var isStandalone = $('[data-behavior~=cvss-calculator]').length > 0;
+  handleVersionSelection();
+  $('[data-behavior~=cvss-error]').addClass('d-none');
 
-    $('[data-behavior~=cvss-buttons] button').on('click', function () {
-      var $this = $(this);
-      var $siblings = $this.parent().find('button');
+  $('[data-behavior~=cvss-buttons] button').on('click', function () {
+    const $btn = $(this);
+    const $siblings = $btn.parent().find('button');
 
-      $siblings.removeClass('active btn-primary');
+    $siblings.removeClass('active btn-primary');
 
-      if (isStandalone) {
-        $siblings.addClass('btn-outline-primary');
-        $this.removeClass('btn-outline-primary');
-      }
+    if (isStandalone) {
+      $siblings.addClass('btn-outline-primary');
+      $btn.removeClass('btn-outline-primary');
+    }
 
-      $this.addClass('active btn-primary');
-      $('input[name="' + $this.attr('name') + '"]').val($this.val());
-      window.calculator.calculate();
-    });
+    $btn.addClass('active btn-primary');
+    $(`input[name="${$btn.attr('name')}"]`).val($btn.val());
+    window.calculator.calculate();
+  });
 
-    $('[data-behavior~=cvss-version]').on('change', handleVersionSelection);
+  $('[data-behavior~=cvss-version]').on('change', handleVersionSelection);
 
-    $('[data-behavior~=cvss-copy-vector]').on('click', function () {
-      var vectorText = $('[data-behavior~=cvss4-vector]').text();
-      navigator.clipboard.writeText(vectorText);
+  $('[data-behavior~=cvss-copy-vector]').on('click', function () {
+    const vectorText = $('[data-behavior~=cvss4-vector]').text();
+    navigator.clipboard.writeText(vectorText);
 
-      var $btn = $(this);
-      $btn.find('i').removeClass('fa-regular fa-copy').addClass('fa-solid fa-check');
-      setTimeout(function () {
-        $btn.find('i').removeClass('fa-solid fa-check').addClass('fa-regular fa-copy');
-      }, 2000);
-    });
-  }
+    const $btn = $(this);
+    $btn.find('i').removeClass('fa-regular fa-copy').addClass('fa-solid fa-check');
+    setTimeout(() => {
+      $btn.find('i').removeClass('fa-solid fa-check').addClass('fa-regular fa-copy');
+    }, 2000);
+  });
 });

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/cvss.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/cvss.js
@@ -20,13 +20,36 @@ $(document).on('turbo:load', function () {
     }
     handleVersionSelection();
     $('[data-behavior~=cvss-error]').addClass('d-none');
+
+    var isStandalone = $('[data-behavior~=cvss-calculator]').length > 0;
+
     $('[data-behavior~=cvss-buttons] button').on('click', function () {
       var $this = $(this);
-      $this.parent().find('button').removeClass('active btn-primary');
+      var $siblings = $this.parent().find('button');
+
+      $siblings.removeClass('active btn-primary');
+
+      if (isStandalone) {
+        $siblings.addClass('btn-outline-primary');
+        $this.removeClass('btn-outline-primary');
+      }
+
       $this.addClass('active btn-primary');
-      $(`input[name="${$this.attr('name')}"]`).val($this.val());
+      $('input[name="' + $this.attr('name') + '"]').val($this.val());
       window.calculator.calculate();
     });
+
     $('[data-behavior~=cvss-version]').on('change', handleVersionSelection);
+
+    $('[data-behavior~=cvss-copy-vector]').on('click', function () {
+      var vectorText = $('[data-behavior~=cvss4-vector]').text();
+      navigator.clipboard.writeText(vectorText);
+
+      var $btn = $(this);
+      $btn.find('i').removeClass('fa-regular fa-copy').addClass('fa-solid fa-check');
+      setTimeout(function () {
+        $btn.find('i').removeClass('fa-solid fa-check').addClass('fa-regular fa-copy');
+      }, 2000);
+    });
   }
 });

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/v4/calculator.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/v4/calculator.js
@@ -210,18 +210,18 @@ class CVSS40Calculator extends CVSS4Calculator {
 
     $('[data-behavior=cvss4-result-text] textarea').val(issue_cvss);
 
-    var score = this.app.score();
-    var severity = this.app.qualScore();
+    const score = this.app.score();
+    const severity = this.app.qualScore();
 
     if ($('[data-behavior=cvss4-severity]').length) {
       $('[data-behavior=cvss4-result]').text(score);
       $('[data-behavior=cvss4-severity]')
         .text(severity)
         .removeClass('cvss-severity-none cvss-severity-low cvss-severity-medium cvss-severity-high cvss-severity-critical')
-        .addClass('cvss-severity-' + severity.toLowerCase());
+        .addClass(`cvss-severity-${severity.toLowerCase()}`);
       $('[data-behavior=cvss4-vector]').text(this.baseVector());
     } else {
-      $('[data-behavior=cvss4-result]').html(score + ' (' + severity + ')');
+      $('[data-behavior=cvss4-result]').html(`${score} (${severity})`);
     }
   }
 }

--- a/app/assets/javascripts/dradis/plugins/calculators/cvss/v4/calculator.js
+++ b/app/assets/javascripts/dradis/plugins/calculators/cvss/v4/calculator.js
@@ -209,8 +209,19 @@ class CVSS40Calculator extends CVSS4Calculator {
     }
 
     $('[data-behavior=cvss4-result-text] textarea').val(issue_cvss);
-    $('[data-behavior=cvss4-result]').html(
-      this.app.score() + ' (' + this.app.qualScore() + ')',
-    );
+
+    var score = this.app.score();
+    var severity = this.app.qualScore();
+
+    if ($('[data-behavior=cvss4-severity]').length) {
+      $('[data-behavior=cvss4-result]').text(score);
+      $('[data-behavior=cvss4-severity]')
+        .text(severity)
+        .removeClass('cvss-severity-none cvss-severity-low cvss-severity-medium cvss-severity-high cvss-severity-critical')
+        .addClass('cvss-severity-' + severity.toLowerCase());
+      $('[data-behavior=cvss4-vector]').text(this.baseVector());
+    } else {
+      $('[data-behavior=cvss4-result]').html(score + ' (' + severity + ')');
+    }
   }
 }

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/_metric_labels.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/_metric_labels.scss
@@ -17,3 +17,12 @@
     margin-left: 0.25rem;
   }
 }
+
+.cvss-btn-group {
+  margin-bottom: 1.5rem;
+}
+
+.cvss-group-title {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/_metric_labels.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/_metric_labels.scss
@@ -1,0 +1,19 @@
+.cvss-metric-label {
+  display: block;
+  margin-bottom: 0.375rem;
+
+  strong {
+    font-weight: 700;
+    margin-right: 0.25rem;
+  }
+
+  span {
+    color: var(--text-muted);
+  }
+
+  i {
+    color: var(--text-muted);
+    cursor: help;
+    margin-left: 0.25rem;
+  }
+}

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -61,7 +61,7 @@
       &.active {
         background: $primary;
         border: 1px solid $primary;
-        box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
+        box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
         color: $white;
       }
     }
@@ -71,7 +71,7 @@
 .cvss-results-panel {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
-  box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
+  box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
   position: sticky;
   top: 1.5rem;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -1,5 +1,254 @@
-@import '_bootstrap';
-@import 'font-awesome';
-
 @import 'hera/variables';
-@import 'hera/modules/buttons';
+
+.cvss-calculator {
+  padding-bottom: 2rem;
+
+  .cvss-metric-group {
+    border: 1px solid $grey-300;
+    border-radius: 0.5rem;
+    margin-bottom: 1.25rem;
+    padding: 1.5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .cvss-section-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.8rem;
+    margin-top: 0;
+  }
+
+  .cvss-group-title {
+    border-bottom: 1px solid $grey-300;
+    color: $grey-600;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    text-transform: uppercase;
+  }
+
+  .cvss-metric-subgroup {
+    margin-top: 2rem;
+    width: 100%;
+
+    &:first-child {
+      margin-top: 1rem;
+    }
+  }
+
+  .cvss-metric-label {
+    display: block;
+    margin-bottom: 0.375rem;
+
+    strong {
+      font-weight: 700;
+      margin-right: 0.25rem;
+    }
+
+    span {
+      color: $grey-600;
+    }
+
+    i {
+      color: $grey-500;
+      cursor: help;
+      margin-left: 0.25rem;
+    }
+  }
+
+  .cvss-btn-group.btn-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+
+    > .btn {
+      border-radius: 2rem !important;
+      flex: none;
+      font-size: 0.8rem;
+      font-weight: 400;
+      margin-left: 0;
+      padding: 0.3rem 0.75rem;
+      white-space: nowrap;
+
+      &:not(.active) {
+        background: $grey-100;
+        border-color: transparent;
+        color: $grey-700;
+
+        &:hover {
+          background: $brand-100;
+          border-color: $primary;
+          color: $primary;
+        }
+      }
+
+      &.active {
+        background: $primary;
+        border-color: $primary;
+        box-shadow: 0 1px 3px rgba($primary, 0.3);
+        color: $white;
+      }
+    }
+  }
+}
+
+.cvss-results-panel {
+  border: 1px solid $grey-300;
+  border-radius: 0.5rem;
+  box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba($grey-600, 0.1);
+  padding: 1.5rem;
+  position: sticky;
+  top: 1.5rem;
+}
+
+.cvss-score-display {
+  align-items: center;
+  display: flex;
+  margin-bottom: 1.5rem;
+}
+
+.cvss-score {
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+  margin-right: 0.75rem;
+}
+
+.cvss-severity-badge {
+  border-radius: 2rem;
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.25rem 0.875rem;
+}
+
+.cvss-severity-none {
+  background: $grey-100;
+  border: 1px solid $grey-800;
+  color: $grey-800;
+}
+
+.cvss-severity-low {
+  background: $blue-100;
+  border: 1px solid $blue-700;
+  color: $blue-700;
+}
+
+.cvss-severity-medium {
+  background: $orange-100;
+  border: 1px solid $orange-700;
+  color: $orange-700;
+}
+
+.cvss-severity-high {
+  background: $red-100;
+  border: 1px solid $red-600;
+  color: $red-600;
+}
+
+.cvss-severity-critical {
+  background: mix($white, $lavender-dark, 85%);
+  border: 1px solid darken($lavender-dark, 20%);
+  color: darken($lavender-dark, 20%);
+}
+
+.cvss-vector-display {
+  margin-bottom: 1.25rem;
+}
+
+.cvss-vector-label {
+  color: $grey-600;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.375rem;
+  text-transform: uppercase;
+}
+
+.cvss-vector-copyable {
+  align-items: center;
+  background: $grey-100;
+  border: 1px solid $grey-300;
+  border-radius: 0.375rem;
+  display: flex;
+  padding: 0.5rem 0.75rem;
+}
+
+.cvss-vector-string {
+  background-color: transparent;
+  color: $grey-700;
+  flex: 1;
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cvss-copy-btn {
+  background: none;
+  border: none;
+  color: $grey-600;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  padding: 0.125rem 0.375rem;
+
+  &:hover {
+    color: $primary;
+  }
+}
+
+.cvss-dradis-output {
+  margin-bottom: 0.5rem;
+}
+
+.cvss-output-label {
+  color: $grey-600;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.375rem;
+  text-transform: uppercase;
+
+  small {
+    font-weight: 400;
+    letter-spacing: 0;
+    margin-top: 0.125rem;
+    text-transform: none;
+  }
+}
+
+.cvss-output-textarea {
+  background: $grey-100;
+  border: 1px solid $grey-300;
+  border-radius: 0.375rem;
+  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  resize: vertical;
+
+  &:focus {
+    border-color: $primary;
+    box-shadow: 0 0 0 0.2rem rgba($primary, 0.15);
+  }
+}
+
+@media (max-width: 991px) {
+  .cvss-results-panel {
+    box-shadow: none;
+    position: static;
+  }
+
+  .cvss-score {
+    font-size: 2.25rem;
+  }
+
+  .cvss-calculator .cvss-btn-group .btn {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.625rem;
+  }
+}

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -15,17 +15,8 @@
     }
   }
 
-  .cvss-section-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 0.8rem;
-    margin-top: 0;
-  }
-
   .cvss-group-title {
     border-bottom: 1px solid $grey-300;
-    color: $grey-600;
-    font-size: 0.8rem;
     letter-spacing: 0.04em;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -58,12 +49,10 @@
 
       &:not(.active) {
         background: $grey-100;
-        border-color: transparent;
         color: $grey-700;
 
         &:hover {
           background: $brand-100;
-          border-color: $primary;
           color: $primary;
         }
       }
@@ -71,7 +60,7 @@
       &.active {
         background: $primary;
         border-color: $primary;
-        box-shadow: 0 1px 3px rgba($primary, 0.3);
+        box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
         color: $white;
       }
     }
@@ -81,7 +70,7 @@
 .cvss-results-panel {
   border: 1px solid $grey-300;
   border-radius: 0.5rem;
-  box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba($grey-600, 0.1);
+  box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
   padding: 1.5rem;
   position: sticky;
   top: 1.5rem;
@@ -145,16 +134,12 @@
 
 .cvss-vector-label,
 .cvss-output-label {
-  color: $grey-600;
-  font-size: 0.7rem;
-  font-weight: 600;
   letter-spacing: 0.04em;
   margin-bottom: 0.375rem;
   text-transform: uppercase;
 }
 
-.cvss-output-label small {
-  font-weight: 400;
+.cvss-output-label span {
   letter-spacing: 0;
   margin-top: 0.125rem;
   text-transform: none;
@@ -182,7 +167,6 @@
 .cvss-copy-btn {
   background: none;
   border: none;
-  color: $grey-600;
   flex-shrink: 0;
   margin-left: 0.5rem;
   padding: 0.125rem 0.375rem;
@@ -197,10 +181,12 @@
 }
 
 .cvss-output-textarea {
-  background: $grey-100;
+  background: $grey-100 !important;
   border: 1px solid $grey-300;
   border-radius: 0.375rem;
-  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
+  color: $grey-700;
+  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo',
+    monospace;
   font-size: 0.75rem;
   line-height: 1.5;
   resize: vertical;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -5,7 +5,7 @@
   padding-bottom: 2rem;
 
   .cvss-metric-group {
-    border: 1px solid $grey-300;
+    border: 1px solid var(--border-color);
     border-radius: 0.5rem;
     margin-bottom: 1.25rem;
     padding: 1.5rem;
@@ -16,7 +16,7 @@
   }
 
   .cvss-group-title {
-    border-bottom: 1px solid $grey-300;
+    border-bottom: 1px solid var(--border-color);
     font-size: 0.875em;
     letter-spacing: 0.04em;
     margin-bottom: 1rem;
@@ -49,8 +49,8 @@
       white-space: nowrap;
 
       &:not(.active) {
-        background: $grey-100;
-        color: $grey-700;
+        background: var(--secondary-bg);
+        color: var(--text-muted);
 
         &:hover {
           background: $brand-100;
@@ -69,7 +69,7 @@
 }
 
 .cvss-results-panel {
-  border: 1px solid $grey-300;
+  border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
   padding: 1.5rem;
@@ -148,8 +148,8 @@
 
 .cvss-vector-copyable {
   align-items: center;
-  background: $grey-100;
-  border: 1px solid $grey-300;
+  background: var(--secondary-bg);
+  border: 1px solid var(--border-color);
   border-radius: 0.375rem;
   display: flex;
   padding: 0.5rem 0.75rem;
@@ -157,7 +157,7 @@
 
 .cvss-vector-string {
   background-color: transparent;
-  color: $grey-700;
+  color: var(--text-muted);
   flex: 1;
   font-size: 0.75rem;
   overflow: hidden;
@@ -182,10 +182,10 @@
 }
 
 .cvss-output-textarea {
-  background: $grey-100 !important;
-  border: 1px solid $grey-300;
+  background: var(--secondary-bg) !important;
+  border: 1px solid var(--border-color);
   border-radius: 0.375rem;
-  color: $grey-700;
+  color: var(--text-muted);
   font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo',
     monospace;
   font-size: 0.75rem;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -17,7 +17,7 @@
 
   .cvss-group-title {
     border-bottom: 1px solid $grey-300;
-    font-size: 0.8rem;
+    font-size: 0.875em;
     letter-spacing: 0.04em;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -135,7 +135,6 @@
 
 .cvss-vector-label,
 .cvss-output-label {
-  font-size: 0.7rem;
   letter-spacing: 0.04em;
   margin-bottom: 0.375rem;
   text-transform: uppercase;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -17,6 +17,7 @@
 
   .cvss-group-title {
     border-bottom: 1px solid $grey-300;
+    font-size: 0.8rem;
     letter-spacing: 0.04em;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -134,6 +135,7 @@
 
 .cvss-vector-label,
 .cvss-output-label {
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   margin-bottom: 0.375rem;
   text-transform: uppercase;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -1,4 +1,5 @@
 @import 'hera/variables';
+@import 'dradis/plugins/calculators/cvss/metric_labels';
 
 .cvss-calculator {
   padding-bottom: 2rem;
@@ -25,7 +26,6 @@
     border-bottom: 1px solid $grey-300;
     color: $grey-600;
     font-size: 0.8rem;
-    font-weight: 600;
     letter-spacing: 0.04em;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -41,30 +41,11 @@
     }
   }
 
-  .cvss-metric-label {
-    display: block;
-    margin-bottom: 0.375rem;
-
-    strong {
-      font-weight: 700;
-      margin-right: 0.25rem;
-    }
-
-    span {
-      color: $grey-600;
-    }
-
-    i {
-      color: $grey-500;
-      cursor: help;
-      margin-left: 0.25rem;
-    }
-  }
-
   .cvss-btn-group.btn-group {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
+    margin-bottom: 1rem;
 
     > .btn {
       border-radius: 2rem !important;
@@ -120,6 +101,7 @@
 }
 
 .cvss-severity-badge {
+  border: 1px solid transparent;
   border-radius: 2rem;
   display: inline-block;
   font-size: 0.8rem;
@@ -129,31 +111,31 @@
 
 .cvss-severity-none {
   background: $grey-100;
-  border: 1px solid $grey-800;
+  border-color: $grey-800;
   color: $grey-800;
 }
 
 .cvss-severity-low {
   background: $blue-100;
-  border: 1px solid $blue-700;
+  border-color: $blue-700;
   color: $blue-700;
 }
 
 .cvss-severity-medium {
   background: $orange-100;
-  border: 1px solid $orange-700;
+  border-color: $orange-700;
   color: $orange-700;
 }
 
 .cvss-severity-high {
   background: $red-100;
-  border: 1px solid $red-600;
+  border-color: $red-600;
   color: $red-600;
 }
 
 .cvss-severity-critical {
   background: mix($white, $lavender-dark, 85%);
-  border: 1px solid darken($lavender-dark, 20%);
+  border-color: darken($lavender-dark, 20%);
   color: darken($lavender-dark, 20%);
 }
 
@@ -161,13 +143,21 @@
   margin-bottom: 1.25rem;
 }
 
-.cvss-vector-label {
+.cvss-vector-label,
+.cvss-output-label {
   color: $grey-600;
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   margin-bottom: 0.375rem;
   text-transform: uppercase;
+}
+
+.cvss-output-label small {
+  font-weight: 400;
+  letter-spacing: 0;
+  margin-top: 0.125rem;
+  text-transform: none;
 }
 
 .cvss-vector-copyable {
@@ -204,22 +194,6 @@
 
 .cvss-dradis-output {
   margin-bottom: 0.5rem;
-}
-
-.cvss-output-label {
-  color: $grey-600;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  margin-bottom: 0.375rem;
-  text-transform: uppercase;
-
-  small {
-    font-weight: 400;
-    letter-spacing: 0;
-    margin-top: 0.125rem;
-    text-transform: none;
-  }
 }
 
 .cvss-output-textarea {

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -61,7 +61,7 @@
       &.active {
         background: $primary;
         border: 1px solid $primary;
-        box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
+        box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba($shadow-color-dark, 0.1);
         color: $white;
       }
     }
@@ -71,7 +71,7 @@
 .cvss-results-panel {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
-  box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0.125rem 0.125rem 0.5rem 0 rgba($shadow-color-dark, 0.1);
   padding: 1.5rem;
   position: sticky;
   top: 1.5rem;

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/base.css.scss
@@ -60,7 +60,7 @@
 
       &.active {
         background: $primary;
-        border-color: $primary;
+        border: 1px solid $primary;
         box-shadow: 0.125rem 0.125rem 0.5rem 0 $shadow-color-light;
         color: $white;
       }

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/manifests/hera.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/manifests/hera.scss
@@ -1,19 +1,2 @@
-.cvss-metric-label {
-  display: block;
-  margin-bottom: 0.375rem;
-
-  strong {
-    font-weight: 700;
-    margin-right: 0.25rem;
-  }
-
-  span {
-    color: var(--text-muted);
-  }
-
-  i {
-    color: var(--text-muted);
-    cursor: help;
-    margin-left: 0.25rem;
-  }
-}
+@import 'hera/variables';
+@import 'dradis/plugins/calculators/cvss/metric_labels';

--- a/app/assets/stylesheets/dradis/plugins/calculators/cvss/manifests/hera.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/cvss/manifests/hera.scss
@@ -1,1 +1,19 @@
-@import 'hera/variables';
+.cvss-metric-label {
+  display: block;
+  margin-bottom: 0.375rem;
+
+  strong {
+    font-weight: 700;
+    margin-right: 0.25rem;
+  }
+
+  span {
+    color: var(--text-muted);
+  }
+
+  i {
+    color: var(--text-muted);
+    cursor: help;
+    margin-left: 0.25rem;
+  }
+}

--- a/app/views/dradis/plugins/calculators/cvss/base/index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/index.html.erb
@@ -1,17 +1,17 @@
-<%= content_tag :div, class: 'page-header' do %>
-  <h1 class="d-flex align-items-center justify-content-between">
-    CVSS score calculator
-    <div class="fs-3"><%= render 'dradis/plugins/calculators/cvss/version_menu' %></div>
-  </h1>
-<% end %>
+<div class="cvss-calculator" data-behavior="cvss-calculator">
+  <div class="page-header d-flex align-items-center justify-content-between mb-4">
+    <h1 class="m-0">CVSS v4.0 Calculator</h1>
+    <div class="fs-6"><%= render 'dradis/plugins/calculators/cvss/version_menu' %></div>
+  </div>
 
-<p class="lead">Use this page to calculate the <abbr title="Common Vulnerability Scoring System">CVSS</abbr> score of a given finding.</p>
+  <p class="lead">Calculate <abbr title="Common Vulnerability Scoring System">CVSS</abbr> scores for your findings.</p>
 
-<p class="alert alert-danger d-none" data-behavior="cvss-error"></p>
+  <p class="alert alert-danger d-none" data-behavior="cvss-error"></p>
 
-<div id="v3-index d-none" data-cvss-version="3">
-  <%= render 'dradis/plugins/calculators/cvss/base/v3/index' %>
-</div>
-<div id="v4-index d-none" data-cvss-version="4">
-  <%= render 'dradis/plugins/calculators/cvss/base/v4/index' %>
+  <div id="v3-index" class="d-none" data-cvss-version="3">
+    <%= render 'dradis/plugins/calculators/cvss/base/v3/index' %>
+  </div>
+  <div id="v4-index" data-cvss-version="4">
+    <%= render 'dradis/plugins/calculators/cvss/base/v4/index' %>
+  </div>
 </div>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
@@ -1,7 +1,7 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Base Metrics">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (AV)">
@@ -9,7 +9,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :av, @cvss4_vector['AV'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'N' %>" name="av" value="N" data-cvss-option="Network (N)">Network (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'A' %>" name="av" value="A" data-cvss-option="Adjacent (A)">Adjacent (A)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'L' %>" name="av" value="L" data-cvss-option="Local (L)">Local (L)</button>
@@ -23,7 +23,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :ac, @cvss4_vector['AC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'L' %>" name="ac" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'H' %>" name="ac" value="H" data-cvss-option="High (H)">High (H)</button>
         </div>
@@ -35,7 +35,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :at, @cvss4_vector['AT'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'N' %>" name="at" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'P' %>" name="at" value="P" data-cvss-option="Present (P)">Present (P)</button>
         </div>
@@ -47,7 +47,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :pr, @cvss4_vector['PR'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'N' %>" name="pr" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'L' %>" name="pr" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'H' %>" name="pr" value="H" data-cvss-option="High (H)">High (H)</button>
@@ -60,7 +60,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :ui, @cvss4_vector['UI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'N' %>" name="ui" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'P' %>" name="ui" value="P" data-cvss-option="Passive (P)">Passive (P)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'A' %>" name="ui" value="A" data-cvss-option="Active (A)">Active (A)</button>
@@ -69,7 +69,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Vulnerable System Impact Metrics</h5>
+      <h5 class="cvss-group-title">Vulnerable System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (VC)">
@@ -77,7 +77,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :vc, @cvss4_vector['VC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'H' %>" name="vc" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'L' %>" name="vc" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'N' %>" name="vc" value="N" data-cvss-option="None (N)">None (N)</button>
@@ -90,7 +90,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :vi, @cvss4_vector['VI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'H' %>" name="vi" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'L' %>" name="vi" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'N' %>" name="vi" value="N" data-cvss-option="None (N)">None (N)</button>
@@ -103,7 +103,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :va, @cvss4_vector['VA'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'H' %>" name="va" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'L' %>" name="va" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'N' %>" name="va" value="N" data-cvss-option="None (N)">None (N)</button>
@@ -112,7 +112,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Subsequent System Impact Metrics</h5>
+      <h5 class="cvss-group-title">Subsequent System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (SC)">
@@ -120,7 +120,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :sc, @cvss4_vector['SC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'H' %>" name="sc" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'L' %>" name="sc" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'N' %>" name="sc" value="N" data-cvss-option="None (N)">None (N)</button>
@@ -133,7 +133,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :si, @cvss4_vector['SI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'H' %>" name="si" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'L' %>" name="si" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'N' %>" name="si" value="N" data-cvss-option="None (N)">None (N)</button>
@@ -146,7 +146,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :sa, @cvss4_vector['SA'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'H' %>" name="sa" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'L' %>" name="sa" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'N' %>" name="sa" value="N" data-cvss-option="None (N)">None (N)</button>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
@@ -1,142 +1,156 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Base Metrics">
   <div class="row">
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="mb-3 fw-bold">Exploitability Metrics</h5>
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Vector (AV)">Attack Vector (AV) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Exploitability Metrics</h5>
 
-      <%= hidden_field_tag :av, @cvss4_vector['AV'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'N' %>" name="av" value="N" data-cvss-option="Network (N)">Network (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'A' %>" name="av" value="A" data-cvss-option="Adjacent (A)">Adjacent (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'L' %>" name="av" value="L" data-cvss-option="Local (L)">Local (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'P' %>" name="av" value="P" data-cvss-option="Physical (P)">Physical (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Vector (AV)">
+          <strong>AV</strong> <span>Attack Vector</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :av, @cvss4_vector['AV'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'N' %>" name="av" value="N" data-cvss-option="Network (N)">Network (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'A' %>" name="av" value="A" data-cvss-option="Adjacent (A)">Adjacent (A)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'L' %>" name="av" value="L" data-cvss-option="Local (L)">Local (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AV'] == 'P' %>" name="av" value="P" data-cvss-option="Physical (P)">Physical (P)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Complexity (AC)">Attack Complexity (AC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :ac, @cvss4_vector['AC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'L' %>" name="ac" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'H' %>" name="ac" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Complexity (AC)">
+          <strong>AC</strong> <span>Attack Complexity</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :ac, @cvss4_vector['AC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'L' %>" name="ac" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AC'] == 'H' %>" name="ac" value="H" data-cvss-option="High (H)">High (H)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Requirements (AT)">Attack Requirements (AT) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :at, @cvss4_vector['AT'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'N' %>" name="at" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'P' %>" name="at" value="P" data-cvss-option="Present (P)">Present (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Requirements (AT)">
+          <strong>AT</strong> <span>Attack Requirements</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :at, @cvss4_vector['AT'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'N' %>" name="at" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AT'] == 'P' %>" name="at" value="P" data-cvss-option="Present (P)">Present (P)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Privileges Required (PR)">Privileges Required (PR) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :pr, @cvss4_vector['PR'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'N' %>" name="pr" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'L' %>" name="pr" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'H' %>" name="pr" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Privileges Required (PR)">
+          <strong>PR</strong> <span>Privileges Required</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :pr, @cvss4_vector['PR'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'N' %>" name="pr" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'L' %>" name="pr" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['PR'] == 'H' %>" name="pr" value="H" data-cvss-option="High (H)">High (H)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="User Interaction (UI)">User Interaction (UI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :ui, @cvss4_vector['UI'] %>
-
-      <div class="btn-group mb-5">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'N' %>" name="ui" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'P' %>" name="ui" value="P" data-cvss-option="Passive (P)">Passive (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'A' %>" name="ui" value="A" data-cvss-option="Active (A)">Active (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="User Interaction (UI)">
+          <strong>UI</strong> <span>User Interaction</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :ui, @cvss4_vector['UI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'N' %>" name="ui" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'P' %>" name="ui" value="P" data-cvss-option="Passive (P)">Passive (P)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['UI'] == 'A' %>" name="ui" value="A" data-cvss-option="Active (A)">Active (A)</button>
+        </div>
       </div>
     </div>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="mb-3 fw-bold">Vulnerable System Impact Metrics</h5>
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Confidentiality (VC)">Confidentiality (VC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Vulnerable System Impact Metrics</h5>
 
-      <%= hidden_field_tag :vc, @cvss4_vector['VC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'H' %>" name="vc" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'L' %>" name="vc" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'N' %>" name="vc" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Confidentiality (VC)">
+          <strong>VC</strong> <span>Confidentiality</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :vc, @cvss4_vector['VC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'H' %>" name="vc" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'L' %>" name="vc" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VC'] == 'N' %>" name="vc" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Integrity (VI)">Integrity (VI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :vi, @cvss4_vector['VI'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'H' %>" name="vi" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'L' %>" name="vi" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'N' %>" name="vi" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Integrity (VI)">
+          <strong>VI</strong> <span>Integrity</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :vi, @cvss4_vector['VI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'H' %>" name="vi" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'L' %>" name="vi" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VI'] == 'N' %>" name="vi" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Availability (VA)">Availability (VA) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :va, @cvss4_vector['VA'] %>
-
-      <div class="btn-group mb-5">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'H' %>" name="va" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'L' %>" name="va" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'N' %>" name="va" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Availability (VA)">
+          <strong>VA</strong> <span>Availability</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :va, @cvss4_vector['VA'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'H' %>" name="va" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'L' %>" name="va" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['VA'] == 'N' %>" name="va" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
-
     </div>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="mb-3 fw-bold">Subsequent System Impact Metrics</h5>
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Confidentiality (SC)">Confidentiality (SC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Subsequent System Impact Metrics</h5>
 
-      <%= hidden_field_tag :sc, @cvss4_vector['SC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'H' %>" name="sc" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'L' %>" name="sc" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'N' %>" name="sc" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Confidentiality (SC)">
+          <strong>SC</strong> <span>Confidentiality</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :sc, @cvss4_vector['SC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'H' %>" name="sc" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'L' %>" name="sc" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SC'] == 'N' %>" name="sc" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Integrity (SI)">Integrity (SI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :si, @cvss4_vector['SI'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'H' %>" name="si" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'L' %>" name="si" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'N' %>" name="si" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Integrity (SI)">
+          <strong>SI</strong> <span>Integrity</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :si, @cvss4_vector['SI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'H' %>" name="si" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'L' %>" name="si" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SI'] == 'N' %>" name="si" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Availability (SA)">Availability (SA) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :sa, @cvss4_vector['SA'] %>
-
-      <div class="btn-group">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'H' %>" name="sa" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'L' %>" name="sa" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'N' %>" name="sa" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Availability (SA)">
+          <strong>SA</strong> <span>Availability</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :sa, @cvss4_vector['SA'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'H' %>" name="sa" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'L' %>" name="sa" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['SA'] == 'N' %>" name="sa" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
@@ -1,7 +1,7 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Base Metrics">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title small">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (AV)">
@@ -69,7 +69,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title small">Vulnerable System Impact Metrics</h5>
+      <h5 class="cvss-group-title">Vulnerable System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (VC)">
@@ -112,7 +112,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title small">Subsequent System Impact Metrics</h5>
+      <h5 class="cvss-group-title">Subsequent System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (SC)">

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_base.html.erb
@@ -1,7 +1,7 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Base Metrics">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title small">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (AV)">
@@ -69,7 +69,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title">Vulnerable System Impact Metrics</h5>
+      <h5 class="cvss-group-title small">Vulnerable System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (VC)">
@@ -112,7 +112,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title">Subsequent System Impact Metrics</h5>
+      <h5 class="cvss-group-title small">Subsequent System Impact Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (SC)">

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
@@ -1,12 +1,12 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Environmental (Modified Base Metrics)">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (MAV)"><strong>MAV</strong> <span>Attack Vector</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mav, @cvss4_vector['MAV'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'X' %>" name="mav" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'N' %>" name="mav" value="N" data-cvss-option="Network (N)">Network (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'A' %>" name="mav" value="A" data-cvss-option="Adjacent (A)">Adjacent (A)</button>
@@ -18,7 +18,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Complexity (MAC)"><strong>MAC</strong> <span>Attack Complexity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mac, @cvss4_vector['MAC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'X' %>" name="mac" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'L' %>" name="mac" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'H' %>" name="mac" value="H" data-cvss-option="High (H)">High (H)</button>
@@ -28,7 +28,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Requirements (MAT)"><strong>MAT</strong> <span>Attack Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mat, @cvss4_vector['MAT'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'X' %>" name="mat" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'N' %>" name="mat" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'P' %>" name="mat" value="P" data-cvss-option="Present (P)">Present (P)</button>
@@ -38,7 +38,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Privileges Required (MPR)"><strong>MPR</strong> <span>Privileges Required</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mpr, @cvss4_vector['MPR'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'X' %>" name="mpr" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'N' %>" name="mpr" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'L' %>" name="mpr" value="L" data-cvss-option="Low (L)">Low (L)</button>
@@ -49,7 +49,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="User Interaction (MUI)"><strong>MUI</strong> <span>User Interaction</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mui, @cvss4_vector['MUI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'X' %>" name="mui" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'N' %>" name="mui" value="N" data-cvss-option="None (N)">None (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'P' %>" name="mui" value="P" data-cvss-option="Passive (P)">Passive (P)</button>
@@ -59,12 +59,12 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Vulnerable System Impact</h5>
+      <h5 class="cvss-group-title">Vulnerable System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MVC)"><strong>MVC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mvc, @cvss4_vector['MVC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'X' %>" name="mvc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'H' %>" name="mvc" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'L' %>" name="mvc" value="L" data-cvss-option="Low (L)">Low (L)</button>
@@ -75,7 +75,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Integrity (MVI)"><strong>MVI</strong> <span>Integrity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mvi, @cvss4_vector['MVI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'X' %>" name="mvi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'H' %>" name="mvi" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'L' %>" name="mvi" value="L" data-cvss-option="Low (L)">Low (L)</button>
@@ -86,7 +86,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Availability (MVA)"><strong>MVA</strong> <span>Availability</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :mva, @cvss4_vector['MVA'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'X' %>" name="mva" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'H' %>" name="mva" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'L' %>" name="mva" value="L" data-cvss-option="Low (L)">Low (L)</button>
@@ -96,12 +96,12 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title mb-3 fw-bold">Subsequent System Impact</h5>
+      <h5 class="cvss-group-title">Subsequent System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MSC)"><strong>MSC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :msc, @cvss4_vector['MSC'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'X' %>" name="msc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'H' %>" name="msc" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'L' %>" name="msc" value="L" data-cvss-option="Low (L)">Low (L)</button>
@@ -112,7 +112,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Integrity (MSI)"><strong>MSI</strong> <span>Integrity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :msi, @cvss4_vector['MSI'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'X' %>" name="msi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'S' %>" name="msi" value="S" data-cvss-option="Safety (S)">Safety (S)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'H' %>" name="msi" value="H" data-cvss-option="High (H)">High (H)</button>
@@ -124,7 +124,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Availability (MSA)"><strong>MSA</strong> <span>Availability</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :msa, @cvss4_vector['MSA'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'X' %>" name="msa" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'S' %>" name="msa" value="S" data-cvss-option="Safety (S)">Safety (S)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'H' %>" name="msa" value="H" data-cvss-option="High (H)">High (H)</button>
@@ -135,12 +135,12 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Environmental (Security Requirements)">
-      <h5 class="cvss-group-title mb-3 fw-bold">Security Requirements</h5>
+      <h5 class="cvss-group-title">Security Requirements</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality Requirements (CR)"><strong>CR</strong> <span>Confidentiality Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :cr, @cvss4_vector['CR'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'X' %>" name="cr" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'H' %>" name="cr" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'M' %>" name="cr" value="M" data-cvss-option="Medium (M)">Medium (M)</button>
@@ -151,7 +151,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Integrity Requirements (IR)"><strong>IR</strong> <span>Integrity Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :ir, @cvss4_vector['IR'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'X' %>" name="ir" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'H' %>" name="ir" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'M' %>" name="ir" value="M" data-cvss-option="Medium (M)">Medium (M)</button>
@@ -162,7 +162,7 @@
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Availability Requirements (AR)"><strong>AR</strong> <span>Availability Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
         <%= hidden_field_tag :ar, @cvss4_vector['AR'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'X' %>" name="ar" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'H' %>" name="ar" value="H" data-cvss-option="High (H)">High (H)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'M' %>" name="ar" value="M" data-cvss-option="Medium (M)">Medium (M)</button>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
@@ -1,219 +1,173 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Environmental (Modified Base Metrics)">
   <div class="row">
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Exploitability Metrics</h5>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="mb-3 fw-bold">Exploitability Metrics</h4>
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Vector (MAV)">Attack Vector (MAV) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mav, @cvss4_vector['MAV'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'X' %>" name="mav" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'N' %>" name="mav" value="N" data-cvss-option="Network (N)">Network (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'A' %>" name="mav" value="A" data-cvss-option="Adjacent (A)">Adjacent (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'L' %>" name="mav" value="L" data-cvss-option="Local (L)">Local (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'P' %>" name="mav" value="P" data-cvss-option="Physical (P)">Physical (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Vector (MAV)"><strong>MAV</strong> <span>Attack Vector</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mav, @cvss4_vector['MAV'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'X' %>" name="mav" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'N' %>" name="mav" value="N" data-cvss-option="Network (N)">Network (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'A' %>" name="mav" value="A" data-cvss-option="Adjacent (A)">Adjacent (A)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'L' %>" name="mav" value="L" data-cvss-option="Local (L)">Local (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAV'] == 'P' %>" name="mav" value="P" data-cvss-option="Physical (P)">Physical (P)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Complexity (MAC)">Attack Complexity (MAC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mac, @cvss4_vector['MAC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'X' %>" name="mac" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'L' %>" name="mac" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'H' %>" name="mac" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Complexity (MAC)"><strong>MAC</strong> <span>Attack Complexity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mac, @cvss4_vector['MAC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'X' %>" name="mac" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'L' %>" name="mac" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAC'] == 'H' %>" name="mac" value="H" data-cvss-option="High (H)">High (H)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Attack Requirements (MAT)">Attack Requirements (MAT) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mat, @cvss4_vector['MAT'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'X' %>" name="mat" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'N' %>" name="mat" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'P' %>" name="mat" value="P" data-cvss-option="Present (P)">Present (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Attack Requirements (MAT)"><strong>MAT</strong> <span>Attack Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mat, @cvss4_vector['MAT'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'X' %>" name="mat" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'N' %>" name="mat" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MAT'] == 'P' %>" name="mat" value="P" data-cvss-option="Present (P)">Present (P)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Privileges Required (MPR)">Privileges Required (MPR) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mpr, @cvss4_vector['MPR'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'X' %>" name="mpr" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'N' %>" name="mpr" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'L' %>" name="mpr" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'H' %>" name="mpr" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Privileges Required (MPR)"><strong>MPR</strong> <span>Privileges Required</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mpr, @cvss4_vector['MPR'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'X' %>" name="mpr" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'N' %>" name="mpr" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'L' %>" name="mpr" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MPR'] == 'H' %>" name="mpr" value="H" data-cvss-option="High (H)">High (H)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="User Interaction (MUI)">User Interaction (MUI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mui, @cvss4_vector['MUI'] %>
-
-      <div class="btn-group mb-5">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'X' %>" name="mui" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'N' %>" name="mui" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'P' %>" name="mui" value="P" data-cvss-option="Passive (P)">Passive (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'A' %>" name="mui" value="A" data-cvss-option="Active (A)">Active (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="User Interaction (MUI)"><strong>MUI</strong> <span>User Interaction</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mui, @cvss4_vector['MUI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'X' %>" name="mui" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'N' %>" name="mui" value="N" data-cvss-option="None (N)">None (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'P' %>" name="mui" value="P" data-cvss-option="Passive (P)">Passive (P)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MUI'] == 'A' %>" name="mui" value="A" data-cvss-option="Active (A)">Active (A)</button>
+        </div>
       </div>
-
     </div>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="mb-3 fw-bold">Vulnerable System Impact Metrics</h4>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Vulnerable System Impact</h5>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Confidentiality (MVC)">Confidentiality (MVC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mvc, @cvss4_vector['MVC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'X' %>" name="mvc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'H' %>" name="mvc" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'L' %>" name="mvc" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'N' %>" name="mvc" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MVC)"><strong>MVC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mvc, @cvss4_vector['MVC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'X' %>" name="mvc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'H' %>" name="mvc" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'L' %>" name="mvc" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVC'] == 'N' %>" name="mvc" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Integrity (MVI)">Integrity (MVI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mvi, @cvss4_vector['MVI'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'X' %>" name="mvi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'H' %>" name="mvi" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'L' %>" name="mvi" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'N' %>" name="mvi" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Integrity (MVI)"><strong>MVI</strong> <span>Integrity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mvi, @cvss4_vector['MVI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'X' %>" name="mvi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'H' %>" name="mvi" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'L' %>" name="mvi" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVI'] == 'N' %>" name="mvi" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Availability (MVA)">Availability (MVA) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :mva, @cvss4_vector['MVA'] %>
-
-      <div class="btn-group mb-5">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'X' %>" name="mva" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'H' %>" name="mva" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'L' %>" name="mva" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'N' %>" name="mva" value="N" data-cvss-option="None (N)">None (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Availability (MVA)"><strong>MVA</strong> <span>Availability</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :mva, @cvss4_vector['MVA'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'X' %>" name="mva" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'H' %>" name="mva" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'L' %>" name="mva" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MVA'] == 'N' %>" name="mva" value="N" data-cvss-option="None (N)">None (N)</button>
+        </div>
       </div>
-
     </div>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="mb-3 fw-bold">Subsequent System Impact Metrics</h4>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
+      <h5 class="cvss-group-title mb-3 fw-bold">Subsequent System Impact</h5>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Confidentiality (MSC)">Confidentiality (MSC) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :msc, @cvss4_vector['MSC'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'X' %>" name="msc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'H' %>" name="msc" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'L' %>" name="msc" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'N' %>" name="msc" value="N" data-cvss-option="Negligible (N)">Negligible (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MSC)"><strong>MSC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :msc, @cvss4_vector['MSC'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'X' %>" name="msc" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'H' %>" name="msc" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'L' %>" name="msc" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSC'] == 'N' %>" name="msc" value="N" data-cvss-option="Negligible (N)">Negligible (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Integrity (MSI)">Integrity (MSI) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :msi, @cvss4_vector['SI'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'X' %>" name="msi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'S' %>" name="msi" value="S" data-cvss-option="Safety (S)">Safety (S) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'H' %>" name="msi" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'L' %>" name="msi" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'N' %>" name="msi" value="N" data-cvss-option="Negligible (N)">Negligible (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Integrity (MSI)"><strong>MSI</strong> <span>Integrity</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :msi, @cvss4_vector['MSI'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'X' %>" name="msi" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'S' %>" name="msi" value="S" data-cvss-option="Safety (S)">Safety (S)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'H' %>" name="msi" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'L' %>" name="msi" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSI'] == 'N' %>" name="msi" value="N" data-cvss-option="Negligible (N)">Negligible (N)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Availability (MSA)">Availability (MSA) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :msa, @cvss4_vector['MSA'] %>
-
-      <div class="btn-group mb-5 mb-xl-0">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'X' %>" name="msa" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'S' %>" name="msa" value="S" data-cvss-option="Safety (S)">Safety (S) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'H' %>" name="msa" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'L' %>" name="msa" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'N' %>" name="msa" value="N" data-cvss-option="Negligible (N)">Negligible (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Availability (MSA)"><strong>MSA</strong> <span>Availability</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :msa, @cvss4_vector['MSA'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'X' %>" name="msa" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'S' %>" name="msa" value="S" data-cvss-option="Safety (S)">Safety (S)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'H' %>" name="msa" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'L' %>" name="msa" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['MSA'] == 'N' %>" name="msa" value="N" data-cvss-option="Negligible (N)">Negligible (N)</button>
+        </div>
       </div>
-
     </div>
 
-    <div class="col-12 col-xl-6" data-cvss-metric-group="Environmental (Security Requirements)">
-      <h5 class="mb-3 fw-bold">Security Requirements</h4>
+    <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Environmental (Security Requirements)">
+      <h5 class="cvss-group-title mb-3 fw-bold">Security Requirements</h5>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Confidentiality Requirements (CR)">Confidentiality Requirements (CR) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :cr, @cvss4_vector['CR'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'X' %>" name="cr" value="X" data-label="Not Defined" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'H' %>" name="cr" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'M' %>" name="cr" value="M" data-cvss-option="Medium (M)">Medium (M) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'L' %>" name="cr" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Confidentiality Requirements (CR)"><strong>CR</strong> <span>Confidentiality Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :cr, @cvss4_vector['CR'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'X' %>" name="cr" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'H' %>" name="cr" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'M' %>" name="cr" value="M" data-cvss-option="Medium (M)">Medium (M)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['CR'] == 'L' %>" name="cr" value="L" data-cvss-option="Low (L)">Low (L)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Integrity Requirements (IR)">Integrity Requirements (IR) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :ir, @cvss4_vector['IR'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'X' %>" name="ir" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'H' %>" name="ir" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'M' %>" name="ir" value="M" data-cvss-option="Medium (M)">Medium (M) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'L' %>" name="ir" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Integrity Requirements (IR)"><strong>IR</strong> <span>Integrity Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :ir, @cvss4_vector['IR'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'X' %>" name="ir" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'H' %>" name="ir" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'M' %>" name="ir" value="M" data-cvss-option="Medium (M)">Medium (M)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['IR'] == 'L' %>" name="ir" value="L" data-cvss-option="Low (L)">Low (L)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Availability Requirements (AR)">Availability Requirements (AR) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :ar, @cvss4_vector['AR'] %>
-
-      <div class="btn-group">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'X' %>" name="ar" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'H' %>" name="ar" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'M' %>" name="ar" value="M" data-cvss-option="Medium (M)">Medium (M) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'L' %>" name="ar" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Availability Requirements (AR)"><strong>AR</strong> <span>Availability Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
+        <%= hidden_field_tag :ar, @cvss4_vector['AR'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'X' %>" name="ar" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'H' %>" name="ar" value="H" data-cvss-option="High (H)">High (H)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'M' %>" name="ar" value="M" data-cvss-option="Medium (M)">Medium (M)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AR'] == 'L' %>" name="ar" value="L" data-cvss-option="Low (L)">Low (L)</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
@@ -1,7 +1,7 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Environmental (Modified Base Metrics)">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title small">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (MAV)"><strong>MAV</strong> <span>Attack Vector</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -59,7 +59,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title small">Vulnerable System Impact</h5>
+      <h5 class="cvss-group-title">Vulnerable System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MVC)"><strong>MVC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -96,7 +96,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title small">Subsequent System Impact</h5>
+      <h5 class="cvss-group-title">Subsequent System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MSC)"><strong>MSC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -135,7 +135,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Environmental (Security Requirements)">
-      <h5 class="cvss-group-title small">Security Requirements</h5>
+      <h5 class="cvss-group-title">Security Requirements</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality Requirements (CR)"><strong>CR</strong> <span>Confidentiality Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_environmental.html.erb
@@ -1,7 +1,7 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Environmental (Modified Base Metrics)">
   <div class="row">
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Exploitability Metrics">
-      <h5 class="cvss-group-title">Exploitability Metrics</h5>
+      <h5 class="cvss-group-title small">Exploitability Metrics</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Attack Vector (MAV)"><strong>MAV</strong> <span>Attack Vector</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -59,7 +59,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Vulnerable System Impact Metrics">
-      <h5 class="cvss-group-title">Vulnerable System Impact</h5>
+      <h5 class="cvss-group-title small">Vulnerable System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MVC)"><strong>MVC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -96,7 +96,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Subsequent System Impact Metrics">
-      <h5 class="cvss-group-title">Subsequent System Impact</h5>
+      <h5 class="cvss-group-title small">Subsequent System Impact</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality (MSC)"><strong>MSC</strong> <span>Confidentiality</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>
@@ -135,7 +135,7 @@
     </div>
 
     <div class="col-12 col-xl-6 cvss-metric-subgroup" data-cvss-metric-group="Environmental (Security Requirements)">
-      <h5 class="cvss-group-title">Security Requirements</h5>
+      <h5 class="cvss-group-title small">Security Requirements</h5>
 
       <div class="cvss-metric">
         <label class="cvss-metric-label" data-cvss-heading="Confidentiality Requirements (CR)"><strong>CR</strong> <span>Confidentiality Requirements</span> <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></label>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <div class="cvss-vector-display">
-        <label class="cvss-vector-label">Vector String</label>
+        <label class="cvss-vector-label small">Vector String</label>
         <div class="cvss-vector-copyable">
           <code class="cvss-vector-string" data-behavior="cvss4-vector">CVSS:4.0</code>
           <button type="button" class="btn btn-sm cvss-copy-btn" data-behavior="cvss-copy-vector" title="Copy to clipboard">

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <div class="cvss-vector-display">
-        <label class="cvss-vector-label small">Vector String</label>
+        <label class="cvss-vector-label">Vector String</label>
         <div class="cvss-vector-copyable">
           <code class="cvss-vector-string" data-behavior="cvss4-vector">CVSS:4.0</code>
           <button type="button" class="btn btn-sm cvss-copy-btn" data-behavior="cvss-copy-vector" title="Copy to clipboard">
@@ -42,7 +42,7 @@
       </div>
 
       <div class="cvss-dradis-output">
-        <label class="cvss-output-label small">
+        <label class="cvss-output-label">
           Dradis field output
           <span class="d-block">Copy this into Dradis to populate issue fields</span>
         </label>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <div class="cvss-vector-display">
-        <label class="cvss-vector-label">Vector String</label>
+        <label class="cvss-vector-label small">Vector String</label>
         <div class="cvss-vector-copyable">
           <code class="cvss-vector-string" data-behavior="cvss4-vector">CVSS:4.0</code>
           <button type="button" class="btn btn-sm cvss-copy-btn" data-behavior="cvss-copy-vector" title="Copy to clipboard">
@@ -42,9 +42,9 @@
       </div>
 
       <div class="cvss-dradis-output">
-        <label class="cvss-output-label">
+        <label class="cvss-output-label small">
           Dradis field output
-          <small class="text-muted d-block">Copy this into Dradis to populate issue fields</small>
+          <span class="d-block">Copy this into Dradis to populate issue fields</span>
         </label>
         <textarea name="cvss_fields" rows="20" class="form-control cvss-output-textarea" readonly></textarea>
       </div>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_index.html.erb
@@ -1,82 +1,53 @@
 <div class="row">
   <div class="col-lg-8">
-    <h3 class="border-bottom border-dark border-opacity-25 pb-1">
-      Base
-    </h3>
-    <%= render 'dradis/plugins/calculators/cvss/base/v4/base' %>
+    <div class="cvss-metric-group" data-cvss-metrics="Base Metrics">
+      <h3 class="cvss-section-title">Base Score</h3>
+      <%= render 'dradis/plugins/calculators/cvss/base/v4/base' %>
+    </div>
 
-    <h3 class="mt-5 border-bottom border-dark border-opacity-25 pb-1">
-      Supplemental
-    </h3>
-    <%= render 'dradis/plugins/calculators/cvss/base/v4/supplemental' %>
+    <div class="cvss-metric-group">
+      <h3 class="cvss-section-title">Supplemental Metrics</h3>
+      <%= render 'dradis/plugins/calculators/cvss/base/v4/supplemental' %>
+    </div>
 
-    <h3 class="mt-5 border-bottom border-dark border-opacity-25 pb-1">
-      Environmental
-    </h3>
-    <%= render 'dradis/plugins/calculators/cvss/base/v4/environmental' %>
+    <div class="cvss-metric-group">
+      <h3 class="cvss-section-title">Environmental Metrics</h3>
+      <%= render 'dradis/plugins/calculators/cvss/base/v4/environmental' %>
+    </div>
 
-    <h3 class="mt-5 border-bottom border-dark border-opacity-25 pb-1">
-      Threat
-    </h3>
-    <div class="mb-4"><%= render 'dradis/plugins/calculators/cvss/base/v4/threat' %></div>
-  </div>
+    <div class="cvss-metric-group">
+      <h3 class="cvss-section-title">Threat Metrics</h3>
+      <%= render 'dradis/plugins/calculators/cvss/base/v4/threat' %>
+    </div>
+  </div><%# /col-lg-8 %>
 
-  <div class="col-lg-4" id="cvss4-edit-result" data-behavior="cvss4-result-text">
-    <h3>
-      Result: <span id="cvss4-score" data-behavior="cvss4-result">0.0 (None)</span>
-    </h3>
-    <textarea name="cvss_fields" rows="52" class="form-control mb-4">#[CVSSv4.Vector]#
-N/A
+  <%# ── Results column (sticky) ── %>
+  <div class="col-lg-4">
+    <div class="cvss-results-panel" data-behavior="cvss4-result-text">
+      <h3 class="cvss-section-title">Result</h3>
 
-#[CVSSv4.BaseScore]#
-N/A
+      <div class="cvss-score-display">
+        <span class="cvss-score" data-behavior="cvss4-result">0.0</span>
+        <span class="cvss-severity-badge cvss-severity-none" data-behavior="cvss4-severity">None</span>
+      </div>
 
-#[CVSSv4.BaseSeverity]#
-N/A
+      <div class="cvss-vector-display">
+        <label class="cvss-vector-label">Vector String</label>
+        <div class="cvss-vector-copyable">
+          <code class="cvss-vector-string" data-behavior="cvss4-vector">CVSS:4.0</code>
+          <button type="button" class="btn btn-sm cvss-copy-btn" data-behavior="cvss-copy-vector" title="Copy to clipboard">
+            <i class="fa-regular fa-copy" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
 
-#[CVSSv4.MacroVector]#
-#[CVSSv4.Expoitability]#
-#[CVSSv4.Complexity]#
-#[CVSSv4.VulnerableSystem]#
-#[CVSSv4.SubsequentSystem]#
-#[CVSSv4.Exploitation]#
-#[CVSSv4.SecurityRequirements]#
-
-#[CVSSv4.BaseExploitableAttackVector]#
-#[CVSSv4.BaseExploitableAttackComplexity]#
-#[CVSSv4.BaseExploitableAttackRequirements]#
-#[CVSSv4.BaseExploitablePrivilegesRequired]#
-#[CVSSv4.BaseExploitableUserInteraction]#
-#[CVSSv4.BaseVulnerableConfidentiality]#
-#[CVSSv4.BaseVulnerableIntegrity]#
-#[CVSSv4.BaseVulnerableAvailability]#
-#[CVSSv4.BaseSubsequentConfidentiality]#
-#[CVSSv4.BaseSubsequentIntegrity]#
-#[CVSSv4.BaseSubsequentAvailability]#
-
-#[CVSSv4.SupplementalSafety]#
-#[CVSSv4.SupplementalAutomatable]#
-#[CVSSv4.SupplementalRecovery]#
-#[CVSSv4.SupplementalValueDensity]#
-#[CVSSv4.SupplementalVulnerabilityResponseEffort]#
-#[CVSSv4.SupplementalProviderUrgency]#
-
-#[CVSSv4.EnvironmentalExploitabilityAttackVector]#
-#[CVSSv4.EnvironmentalExploitabilityAttackComplexity]#
-#[CVSSv4.EnvironmentalExploitabilityAttackRequirements]#
-#[CVSSv4.EnvironmentalExploitabilityPrivilegesRequired]#
-#[CVSSv4.EnvironmentalExploitabilityUserInteraction]#
-#[CVSSv4.EnvironmentalVulnerableConfidentiality]#
-#[CVSSv4.EnvironmentalVulnerableIntegrity]#
-#[CVSSv4.EnvironmentalVulnerableAvailability]#
-#[CVSSv4.EnvironmentalSubsequentConfidentiality]#
-#[CVSSv4.EnvironmentalSubsequentIntegrity]#
-#[CVSSv4.EnvironmentalSubsequentAvailability]#
-#[CVSSv4.EnvironmentalConfidentialityRequirements]#
-#[CVSSv4.EnvironmentalIntegrityRequirements]#
-#[CVSSv4.EnvironmentalAvailabilityRequirements]#
-
-#[CVSSv4.ThreatExploitMaturity]#
-    </textarea>
-  </div>
-</div>
+      <div class="cvss-dradis-output">
+        <label class="cvss-output-label">
+          Dradis field output
+          <small class="text-muted d-block">Copy this into Dradis to populate issue fields</small>
+        </label>
+        <textarea name="cvss_fields" rows="20" class="form-control cvss-output-textarea" readonly></textarea>
+      </div>
+    </div>
+  </div><%# /col-lg-4 %>
+</div><%# /row %>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_supplemental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_supplemental.html.erb
@@ -1,84 +1,86 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Supplemental Metrics">
   <div class="row">
-    <div class="col-12" data-cvss-metric-group="none">
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Safety (S)">Safety (S) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :s, @cvss4_vector['S'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'X' %>" name="s" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'N' %>" name="s" value="N" data-cvss-option="Negligible (N)">Negligible (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'P' %>" name="s" value="P" data-cvss-option="Present (P)">Present (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+    <div class="col-12 cvss-metric-subgroup" data-cvss-metric-group="none">
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Safety (S)">
+          <strong>S</strong> <span>Safety</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :s, @cvss4_vector['S'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'X' %>" name="s" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'N' %>" name="s" value="N" data-cvss-option="Negligible (N)">Negligible (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'P' %>" name="s" value="P" data-cvss-option="Present (P)">Present (P)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0" data-cvss-heading="Automatable (AU)">Automatable (AU) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :au, @cvss4_vector['AU'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'X' %>" name="au" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'N' %>" name="au" value="N" data-cvss-option="No (N)">No (N) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'Y' %>" name="au" value="Y" data-cvss-option="Yes (Y)">Yes (Y) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Automatable (AU)">
+          <strong>AU</strong> <span>Automatable</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :au, @cvss4_vector['AU'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'X' %>" name="au" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'N' %>" name="au" value="N" data-cvss-option="No (N)">No (N)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'Y' %>" name="au" value="Y" data-cvss-option="Yes (Y)">Yes (Y)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0" data-cvss-heading="Recovery (R)">Recovery (R) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :r, @cvss4_vector['R'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'X' %>" name="r" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'A' %>" name="r" value="A"  data-cvss-option="Automatic (A)">Automatic (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'U' %>" name="r" value="U" data-cvss-option="User (U)">User (U) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'I' %>" name="r" value="I" data-cvss-option="Irrecoverable (I)">Irrecoverable (I) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Recovery (R)">
+          <strong>R</strong> <span>Recovery</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :r, @cvss4_vector['R'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'X' %>" name="r" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'A' %>" name="r" value="A" data-cvss-option="Automatic (A)">Automatic (A)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'U' %>" name="r" value="U" data-cvss-option="User (U)">User (U)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'I' %>" name="r" value="I" data-cvss-option="Irrecoverable (I)">Irrecoverable (I)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0" data-cvss-heading="Value Density (V)">Value Density (V) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :v, @cvss4_vector['V'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'X' %>" name="v" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'D' %>" name="v" value="D" data-cvss-option="Diffuse (D)">Diffuse (D) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'C' %>" name="v" value="C" data-cvss-option="Concentrated (C)">Concentrated (C) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Value Density (V)">
+          <strong>V</strong> <span>Value Density</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :v, @cvss4_vector['V'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'X' %>" name="v" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'D' %>" name="v" value="D" data-cvss-option="Diffuse (D)">Diffuse (D)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'C' %>" name="v" value="C" data-cvss-option="Concentrated (C)">Concentrated (C)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0" data-cvss-heading="Vulnerability Response Effort (RE)">Vulnerability Response Effort (RE) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :re, @cvss4_vector['RE'] %>
-
-      <div class="btn-group mb-4">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'X' %>" name="re" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'L' %>" name="re" value="L" data-cvss-option="Low (L)">Low (L) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'M' %>" name="re" value="M" data-cvss-option="Moderate (M)">Moderate (M) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'H' %>" name="re" value="H" data-cvss-option="High (H)">High (H) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Vulnerability Response Effort (RE)">
+          <strong>RE</strong> <span>Vulnerability Response Effort</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :re, @cvss4_vector['RE'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'X' %>" name="re" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'L' %>" name="re" value="L" data-cvss-option="Low (L)">Low (L)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'M' %>" name="re" value="M" data-cvss-option="Moderate (M)">Moderate (M)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'H' %>" name="re" value="H" data-cvss-option="High (H)">High (H)</button>
+        </div>
       </div>
 
-      <h5 class="header-underline mt-0" data-cvss-heading="Provider Urgency (U)">Provider Urgency (U) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :u, @cvss4_vector['U'] %>
-
-      <div class="btn-group">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'X' %>" name="u" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Clear' %>" name="u" value="Clear" data-cvss-option="Clear">Clear <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Green' %>" name="u" value="Green" data-cvss-option="Green">Green <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Amber' %>" name="u" value="Amber" data-cvss-option="Amber">Amber <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Red' %>" name="u" value="Red" data-cvss-option="Red">Red <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Provider Urgency (U)">
+          <strong>U</strong> <span>Provider Urgency</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :u, @cvss4_vector['U'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'X' %>" name="u" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Clear' %>" name="u" value="Clear" data-cvss-option="Clear">Clear</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Green' %>" name="u" value="Green" data-cvss-option="Green">Green</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Amber' %>" name="u" value="Amber" data-cvss-option="Amber">Amber</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Red' %>" name="u" value="Red" data-cvss-option="Red">Red</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_supplemental.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_supplemental.html.erb
@@ -7,7 +7,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :s, @cvss4_vector['S'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'X' %>" name="s" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'N' %>" name="s" value="N" data-cvss-option="Negligible (N)">Negligible (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['S'] == 'P' %>" name="s" value="P" data-cvss-option="Present (P)">Present (P)</button>
@@ -20,7 +20,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :au, @cvss4_vector['AU'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'X' %>" name="au" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'N' %>" name="au" value="N" data-cvss-option="No (N)">No (N)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['AU'] == 'Y' %>" name="au" value="Y" data-cvss-option="Yes (Y)">Yes (Y)</button>
@@ -33,7 +33,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :r, @cvss4_vector['R'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'X' %>" name="r" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'A' %>" name="r" value="A" data-cvss-option="Automatic (A)">Automatic (A)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['R'] == 'U' %>" name="r" value="U" data-cvss-option="User (U)">User (U)</button>
@@ -47,7 +47,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :v, @cvss4_vector['V'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'X' %>" name="v" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'D' %>" name="v" value="D" data-cvss-option="Diffuse (D)">Diffuse (D)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['V'] == 'C' %>" name="v" value="C" data-cvss-option="Concentrated (C)">Concentrated (C)</button>
@@ -60,7 +60,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :re, @cvss4_vector['RE'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'X' %>" name="re" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'L' %>" name="re" value="L" data-cvss-option="Low (L)">Low (L)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['RE'] == 'M' %>" name="re" value="M" data-cvss-option="Moderate (M)">Moderate (M)</button>
@@ -74,7 +74,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :u, @cvss4_vector['U'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'X' %>" name="u" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Clear' %>" name="u" value="Clear" data-cvss-option="Clear">Clear</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['U'] == 'Green' %>" name="u" value="Green" data-cvss-option="Green">Green</button>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_threat.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_threat.html.erb
@@ -7,7 +7,7 @@
           <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
         </label>
         <%= hidden_field_tag :e, @cvss4_vector['E'] %>
-        <div class="btn-group cvss-btn-group mb-4">
+        <div class="btn-group cvss-btn-group">
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'X' %>" name="e" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'A' %>" name="e" value="A" data-cvss-option="Attacked (A)">Attacked (A)</button>
           <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'P' %>" name="e" value="P" data-cvss-option="POC (P)">POC (P)</button>

--- a/app/views/dradis/plugins/calculators/cvss/base/v4/_threat.html.erb
+++ b/app/views/dradis/plugins/calculators/cvss/base/v4/_threat.html.erb
@@ -1,18 +1,18 @@
 <section data-behavior="cvss-buttons" data-cvss-version="4" data-cvss-metrics="Threat Metrics">
   <div class="row">
-    <div class="col-12" data-cvss-metric-group="none">
-      <h5 class="header-underline mt-0 align-items-center gap-2" data-cvss-heading="Exploit Maturity (E)">Exploit Maturity (E) <i class="fa-regular fa-question-circle small" aria-hidden="true"></i></h5>
-
-      <%= hidden_field_tag :e, @cvss4_vector['E'] %>
-
-      <div class="btn-group">
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'X' %>" name="e" value="X" data-cvss-option="Not Defined (X)">Not Defined (X) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'A' %>" name="e" value="A" data-cvss-option="Attacked (A)">Attacked (A) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'P' %>" name="e" value="P" data-cvss-option="POC (P)">POC (P) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
-
-        <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'U' %>" name="e" value="U" data-cvss-option="Unreported (U)">Unreported (U) <i class="fa-regular fa-question-circle" aria-hidden="true"></i></button>
+    <div class="col-12 cvss-metric-subgroup" data-cvss-metric-group="none">
+      <div class="cvss-metric">
+        <label class="cvss-metric-label" data-cvss-heading="Exploit Maturity (E)">
+          <strong>E</strong> <span>Exploit Maturity</span>
+          <i class="fa-regular fa-question-circle small" aria-hidden="true"></i>
+        </label>
+        <%= hidden_field_tag :e, @cvss4_vector['E'] %>
+        <div class="btn-group cvss-btn-group mb-4">
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'X' %>" name="e" value="X" data-cvss-option="Not Defined (X)">Not Defined (X)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'A' %>" name="e" value="A" data-cvss-option="Attacked (A)">Attacked (A)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'P' %>" name="e" value="P" data-cvss-option="POC (P)">POC (P)</button>
+          <button type="button" class="btn <%= 'active btn-primary' if @cvss4_vector['E'] == 'U' %>" name="e" value="U" data-cvss-option="Unreported (U)">Unreported (U)</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/layouts/dradis/plugins/calculators/cvss/base.html.erb
+++ b/app/views/layouts/dradis/plugins/calculators/cvss/base.html.erb
@@ -2,7 +2,9 @@
 <html>
   <head>
     <title>CVSS Score Calculator | Dradis Framework</title>
+    <%= stylesheet_link_tag    'hera', media: 'all', 'data-turbo-track': 'reload' %>
     <%= stylesheet_link_tag    'dradis/plugins/calculators/cvss/base', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'hera', 'data-turbo-track': 'reload' %>
     <%= javascript_include_tag 'dradis/plugins/calculators/cvss/base', 'data-turbo-track': 'reload' %>
     <%= csrf_meta_tags %>
     <%= javascript_importmap_tags %>
@@ -10,19 +12,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="authenticated">
-    <div class="container">
-      <nav class="navbar">
+    <div class="container py-4">
+      <nav class="navbar mb-3">
         <a href="javascript:void(0)" class="navbar-brand">CVSS score calculator</a>
-        <ul class="navbar-nav pull-right">
+        <ul class="navbar-nav ms-auto">
           <li class="nav-item">
             <%= link_to main_app.root_path, class: 'nav-link', data: { turbo: false } do %>
-            Back to the app  &rarr;
+              Back to the app &rarr;
             <% end %>
           </li>
         </ul>
       </nav>
 
-      <%= yield%>
+      <%= yield %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### Summary

Redesign the standalone CVSS calculator (Tools menu) with a two-column layout, sticky results panel, pill-style metric buttons, severity badges, vector string display with copy-to-clipboard, and improved metric labels. Shared partials are updated to work in both the standalone and in-app (Issues#show) contexts.

### Testing Steps

- Navigate to the standalone calculator via Tools > Risk Calculators - CVSS
- Select Base metrics and verify the score, severity badge, and vector string update in the sticky results panel
- Test copy-to-clipboard on the vector string
- Verify the Dradis field output textarea populates correctly
- Test all severity levels: None (grey), Low (blue), Medium (orange), High (red), Critical (purple)
- Navigate to an issue's CVSS edit view and verify the metric labels render correctly in the tabbed layout
- Verify the version switcher (v4.0/v3.1/v3.0) still works on the standalone page

### Check List

- [x] Added a CHANGELOG entry
- ~~Added specs~~